### PR TITLE
cuda(async) —> cuda(non_blocking) for Python >= 3.7

### DIFF
--- a/lib/nn/parallel/data_parallel.py
+++ b/lib/nn/parallel/data_parallel.py
@@ -13,7 +13,7 @@ def async_copy_to(obj, dev, main_stream=None):
     if torch.is_tensor(obj):
         obj = Variable(obj)
     if isinstance(obj, Variable):
-        v = obj.cuda(dev, async=True)
+        v = obj.cuda(dev, non_blocking=True)
         if main_stream is not None:
             v.data.record_stream(main_stream)
         return v


### PR DESCRIPTION
Fixes #125 

__async__ is a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async=True)__ to __cuda(non_blocking=True)__ so this PR tracks with that change which landed in PyTourch 0.4.1.