### PR TITLE
Fix argument imgs in test

### DIFF
--- a/test.py
+++ b/test.py
@@ -185,8 +185,8 @@ if __name__ == '__main__':
         os.path.exists(cfg.MODEL.weights_decoder), "checkpoint does not exitst!"
 
     # generate testing image list
-    if os.path.isdir(args.imgs[0]):
-        imgs = find_recursive(args.imgs[0])
+    if os.path.isdir(args.imgs):
+        imgs = find_recursive(args.imgs)
     else:
         imgs = [args.imgs]
     assert len(imgs), "imgs should be a path to image (.jpg) or directory."

--- a/test.py
+++ b/test.py
@@ -141,7 +141,7 @@ if __name__ == '__main__':
         "--imgs",
         required=True,
         type=str,
-        help="an image paths, or a directory name"
+        help="an image path, or a directory name"
     )
     parser.add_argument(
         "--cfg",


### PR DESCRIPTION
## Fixed issues
* ```python3 -u test.py--imgs {FOLDER_NAME}``` got error as mentioned in Fixes #226 by @sibadakesi
* ```python3 -u test.py--imgs {IMAGE_PATH}``` also got error (or return inferences for all of images under '/')

## Response from a command
*  a original sample directory 'test_data' is specified.
### Before
![before](https://user-images.githubusercontent.com/60654612/83064823-68fde200-a09d-11ea-99b7-3b549073b169.png)
)

### After
![after](https://user-images.githubusercontent.com/60654612/83064940-98145380-a09d-11ea-9967-f83c80da21b3.png)