### PR TITLE
Fix ade20k-resnet101-upernet checkpoint link

### DIFF
--- a/config/ade20k-resnet101-upernet.yaml
+++ b/config/ade20k-resnet101-upernet.yaml
@@ -33,10 +33,10 @@ TRAIN:
 
 VAL:
   visualize: False
-  checkpoint: "epoch_40.pth"
+  checkpoint: "epoch_50.pth"
 
 TEST:
-  checkpoint: "epoch_40.pth"
+  checkpoint: "epoch_50.pth"
   result: "./"
 
 DIR: "ckpt/ade20k-resnet101-upernet"


### PR DESCRIPTION
That should fix issue #91  I suppose.

You provide a epoch_50 at http://sceneparsing.csail.mit.edu/model/pytorch/ade20k-resnet101-upernet/  and not an epoch_40