### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-pytorch=0.4.1
+pytorch==0.4.1
 torchvision
 opencv3
 yacs


### PR DESCRIPTION
According to https://pip.pypa.io/en/stable/user_guide/ to set the version of torch "==" should be used. Otherwise one recieves the following error:
```
ERROR: Invalid requirement: 'pytorch=0.4.1' (from line 3 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?       
```