### PR TITLE
Update pip packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
-pytorch==0.4.1
+torch
 torchvision
-opencv3
+opencv-python
 yacs
 tqdm


### PR DESCRIPTION
- pytorch 0.4.1 is deprecated
- PyTorch package name has changed from pytorch to toch
- Package name of opencv3 is not available
